### PR TITLE
[FND 1655] Added function to load embeddings

### DIFF
--- a/src/embedding_service.py
+++ b/src/embedding_service.py
@@ -1,3 +1,5 @@
+import faiss
+import numpy as np
 import pandas as pd
 from core.embeddings.base import Embeddings
 from utils.logging import logger
@@ -64,3 +66,13 @@ def create_embeddings(
     logger.info("All labels embedded and CSV updated.")
 
     return embedding_df
+
+
+def initialize_faiss_index_from_embeddings(
+    embed_model: Embeddings, df: pd.DataFrame, embed_col="embedding"
+):
+    embeddings_array = np.array(df[embed_col].tolist(), dtype=np.float32)
+    index = faiss.IndexFlatL2(embed_model.dims)
+    index.add(embeddings_array)
+
+    return index

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -6,7 +6,7 @@ from numpy.random import random
 from pandas.testing import assert_frame_equal
 
 from src.core.embeddings.bedrock import BedrockEmbeddings
-from src.embedding_service import create_embeddings
+from src.embedding_service import create_embeddings, initialize_faiss_index_from_embeddings
 
 
 class TestBedrockEmbeddings(unittest.TestCase):
@@ -101,7 +101,6 @@ class TestBedrockEmbeddings(unittest.TestCase):
     def test_create_embeddings_full_complete(self, mock_client):
         model_id = "amazon.titan-v1"
         aws_region_name = "eu-central-1"
-        client = mock_client
 
         df = pd.DataFrame(
             {
@@ -131,10 +130,39 @@ class TestBedrockEmbeddings(unittest.TestCase):
 
         output_csv_filepath = "test.csv"
 
-        bedrock_embeddings = BedrockEmbeddings(model_id, aws_region_name, client)
+        bedrock_embeddings = BedrockEmbeddings(model_id, aws_region_name, mock_client)
         with patch("pandas.read_csv") as mock_read_csv:
             mock_read_csv.return_value = df
 
             output = create_embeddings(bedrock_embeddings, df, output_csv_filepath)
 
             assert_frame_equal(expected_output, output)
+
+    @patch("boto3.client")
+    def test_initialize_faiss_index_from_embeddings(self, mock_client):
+        model_id = "amazon.titan-v1"
+        aws_region_name = "eu-central-1"
+        dims = 3
+
+        df = pd.DataFrame(
+            {
+                "embedding": [[1.1, 2.2, 3.1], [0.1, 2.3, 0.3], [2.1, 1.2, 0.3]],
+            }
+        )
+
+        bedrock_embeddings = BedrockEmbeddings(model_id, aws_region_name, mock_client, dims=dims)
+
+        index = initialize_faiss_index_from_embeddings(bedrock_embeddings, df)
+        self.assertIsNotNone(index)
+
+    @patch("boto3.client")
+    def test_initialize_faiss_index_from_embeddings_invalid_input(self, mock_client):
+        model_id = "amazon.titan-v1"
+        aws_region_name = "eu-central-1"
+        dims = 3
+
+        df = pd.DataFrame({"embedding": [1, 2, 3]})
+
+        bedrock_embeddings = BedrockEmbeddings(model_id, aws_region_name, mock_client, dims=dims)
+        with self.assertRaises(ValueError):
+            initialize_faiss_index_from_embeddings(bedrock_embeddings, df)


### PR DESCRIPTION
In the OG cocoon we load the NAICS or Ecoinvent embeddings stored in the S3 bucket into FAISS. The function `initialize_faiss_index_from_embeddings` does the same thing.